### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 Built at AGI House MCP Hackathon
 
+<a href="https://glama.ai/mcp/servers/@ashley-ha/mcp-manus">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ashley-ha/mcp-manus/badge" alt="Browser Agent MCP server" />
+</a>
+
 ## Overview
 
 This project is a browser automation agent that uses the Model Context Protocol (MCP) to enable browser interactions. It provides a seamless integration between Claude and browser automation capabilities through our MCP server. 


### PR DESCRIPTION
This PR adds a badge for the [MCP Browser Agent](https://glama.ai/mcp/servers/@ashley-ha/mcp-manus) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@ashley-ha/mcp-manus">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@ashley-ha/mcp-manus/badge" alt="Browser Agent MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.